### PR TITLE
Fix transform values validation

### DIFF
--- a/index.js
+++ b/index.js
@@ -401,7 +401,7 @@ const deprecatedAttributes = [
 function isValidTransformValue(value) {
   const allowedFunctions = ["translate", "scale", "rotate", "skewX", "skewY", "matrix"];
   // Regex: one or more function calls, with no invalid chars between.
-  const regex = new RegExp(`^(?:\\s*(?:${allowedFunctions.join("|")})\\s*\$begin:math:text$[^\\$end:math:text$]*\\)\\s*)+$`);
+  const regex = new RegExp(`^(?:\\s*(?:${allowedFunctions.join("|")})\\s*\\([^\\)]*\\)\\s*)+$`)
   if (!regex.test(value)) {
     return {
       valid: false,


### PR DESCRIPTION
The regular expression in `isValidTransformValue` appears to have artifacts (from Markdown-math?) that cause spurious validation errors like `"On <rect>: Invalid transform value: rotate(180, 100, 155)"`. This replaces the artifacts with what I believe was intended.